### PR TITLE
fix: requests package version range

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.11.1
+requests>=2.11.1,<3.0
 cachecontrol==0.11.6
 hyper==0.7.0
 h2==2.4.2


### PR DESCRIPTION
reference #9. Wercker is blocking me on other packages because opentargets-py is too restricted specifying `requests` package version