### PR TITLE
Update travis badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # opentargets-py
 Python client for the Open Targets REST API at api.opentargets.io
-[![Build Status](https://travis-ci.org/opentargets/opentargets-py.svg?branch=master)](https://travis-ci.org/opentargets/opentargets-py)
+[![Build Status](https://travis-ci.com/opentargets/opentargets-py.svg?branch=master)](https://travis-ci.com/opentargets/opentargets-py)
 [![Documentation Status](https://readthedocs.org/projects/opentargets/badge/?version=latest)](http://opentargets.readthedocs.io/en/latest/?badge=latest)
 
 Why should you use this client instead of the REST API directly?


### PR DESCRIPTION
Since we moved this from travis-ci.org to travis-ci.com we need to update the badge accordingly.