### PR TITLE
Fix for issue #38; missing fields parameters.

### DIFF
--- a/opentargets/__init__.py
+++ b/opentargets/__init__.py
@@ -136,7 +136,7 @@ class OpenTargetsClient(object):
         """
         if not isinstance(disease, str):
             raise AttributeError('disease must be of type str')
-        results = self.filter_associations(disease=disease)
+        results = self.filter_associations(disease=disease, **kwargs)
         if not results:
             search_result = next(self.search(disease, size=1, filter='disease'))
             if not search_result:


### PR DESCRIPTION
# Issue #38 of missing fields parameters 

## Problem: 
The filter_assocations method doesn't allow passing fields parameters.
```python
results = self.filter_associations(disease=disease)
```
## Solution:
Include **kwargs
```python
results = self.filter_associations(disease=disease, **kwargs)
```